### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/src/common.ml
+++ b/src/common.ml
@@ -78,7 +78,7 @@ module Remote = struct
   open Cohttp
   open Cohttp_lwt_unix
 
-  let default_remote = "https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
+  let default_remote = "https://raw.githubusercontent.com/tldr-pages/tldr/main/pages"
 
   let get_page_url ?(remote = default_remote) ?(platform = Environment.system) command =
     String.concat ~sep:"" [remote; "/"; platform; "/"; command; ".md"]


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the `master` branch in favor of the `main` branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).